### PR TITLE
实现可切换的 OpenAI 请求地址功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ https://developers.cloudflare.com/workers-ai/models/
 | CF_TOKEN       | Cloudflare Workers AI Token        |  
 | CF_GATEWAY     | Cloudflare AI Gateway URL          |    
 | OPENAI_API_KEY | OpenAI API Key (需要ChatGPT时填写)      |     
-| OPENAI_API_URL | OpenAI API 请求地址(需要ChatGPT时填写,如果不填则为CF_GATEWAY) |
+| OPENAI_API_URL | 自定义OpenAI API请求地址 |
 | G_API_KEY      | Google AI API Key (需要GeminiPro时填写) | 
 | G_API_URL      | Google AI 反代 (不支持地区填写，或参考以下配置)     |    
 | PASSWORD       | 访问密码 (可选)                          |   

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ https://developers.cloudflare.com/workers-ai/models/
 | CF_TOKEN       | Cloudflare Workers AI Token        |  
 | CF_GATEWAY     | Cloudflare AI Gateway URL          |    
 | OPENAI_API_KEY | OpenAI API Key (需要ChatGPT时填写)      |     
+| OPENAI_API_URL | OpenAI API 请求地址(需要ChatGPT时填写,如果不填则为CF_GATEWAY) |
 | G_API_KEY      | Google AI API Key (需要GeminiPro时填写) | 
 | G_API_URL      | Google AI 反代 (不支持地区填写，或参考以下配置)     |    
 | PASSWORD       | 访问密码 (可选)                          |   


### PR DESCRIPTION
解决了 [#59](https://github.com/Jazee6/cloudflare-ai-web/issues/59)
修改了server/api/auth/openai.post.ts
修改了README.md
可以实现用户自行更换chatgpt请求地址